### PR TITLE
Feature/frontify6 31

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20795,15 +20795,15 @@
                     }
                 },
                 "caniuse-lite": {
-                    "version": "1.0.30001306",
-                    "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001306.tgz",
-                    "integrity": "sha512-Wd1OuggRzg1rbnM5hv1wXs2VkxJH/AA+LuudlIqvZiCvivF+wJJe2mgBZC8gPMgI7D76PP5CTx8Luvaqc1V6OQ==",
+                    "version": "1.0.30001307",
+                    "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001307.tgz",
+                    "integrity": "sha512-+MXEMczJ4FuxJAUp0jvAl6Df0NI/OfW1RWEE61eSmzS7hw6lz4IKutbhbXendwq8BljfFuHtu26VWsg4afQ7Ng==",
                     "dev": true
                 },
                 "electron-to-chromium": {
-                    "version": "1.4.63",
-                    "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.63.tgz",
-                    "integrity": "sha512-e0PX/LRJPFRU4kzJKLvTobxyFdnANCvcoDCe8XcyTqP58nTWIwdsHvXLIl1RkB39X5yaosLaroMASWB0oIsgCA==",
+                    "version": "1.4.64",
+                    "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.64.tgz",
+                    "integrity": "sha512-8mec/99xgLUZCIZZq3wt61Tpxg55jnOSpxGYapE/1Ma9MpFEYYaz4QNYm0CM1rrnCo7i3FRHhbaWjeCLsveGjQ==",
                     "dev": true
                 },
                 "node-releases": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -3164,6 +3164,78 @@
                 "minimist": "^1.2.0"
             }
         },
+        "@csstools/postcss-font-format-keywords": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/@csstools/postcss-font-format-keywords/-/postcss-font-format-keywords-1.0.0.tgz",
+            "integrity": "sha512-oO0cZt8do8FdVBX8INftvIA4lUrKUSCcWUf9IwH9IPWOgKT22oAZFXeHLoDK7nhB2SmkNycp5brxfNMRLIhd6Q==",
+            "dev": true,
+            "requires": {
+                "postcss-value-parser": "^4.2.0"
+            },
+            "dependencies": {
+                "postcss-value-parser": {
+                    "version": "4.2.0",
+                    "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
+                    "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
+                    "dev": true
+                }
+            }
+        },
+        "@csstools/postcss-hwb-function": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/@csstools/postcss-hwb-function/-/postcss-hwb-function-1.0.0.tgz",
+            "integrity": "sha512-VSTd7hGjmde4rTj1rR30sokY3ONJph1reCBTUXqeW1fKwETPy1x4t/XIeaaqbMbC5Xg4SM/lyXZ2S8NELT2TaA==",
+            "dev": true,
+            "requires": {
+                "postcss-value-parser": "^4.2.0"
+            },
+            "dependencies": {
+                "postcss-value-parser": {
+                    "version": "4.2.0",
+                    "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
+                    "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
+                    "dev": true
+                }
+            }
+        },
+        "@csstools/postcss-is-pseudo-class": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/@csstools/postcss-is-pseudo-class/-/postcss-is-pseudo-class-2.0.0.tgz",
+            "integrity": "sha512-WnfZlyuh/CW4oS530HBbrKq0G8BKl/bsNr5NMFoubBFzJfvFRGJhplCgIJYWUidLuL3WJ/zhMtDIyNFTqhx63Q==",
+            "dev": true,
+            "requires": {
+                "postcss-selector-parser": "^6.0.9"
+            },
+            "dependencies": {
+                "postcss-selector-parser": {
+                    "version": "6.0.9",
+                    "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.9.tgz",
+                    "integrity": "sha512-UO3SgnZOVTwu4kyLR22UQ1xZh086RyNZppb7lLAKBFK8a32ttG5i87Y/P3+2bRSjZNyJ1B7hfFNo273tKe9YxQ==",
+                    "dev": true,
+                    "requires": {
+                        "cssesc": "^3.0.0",
+                        "util-deprecate": "^1.0.2"
+                    }
+                }
+            }
+        },
+        "@csstools/postcss-normalize-display-values": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/@csstools/postcss-normalize-display-values/-/postcss-normalize-display-values-1.0.0.tgz",
+            "integrity": "sha512-bX+nx5V8XTJEmGtpWTO6kywdS725t71YSLlxWt78XoHUbELWgoCXeOFymRJmL3SU1TLlKSIi7v52EWqe60vJTQ==",
+            "dev": true,
+            "requires": {
+                "postcss-value-parser": "^4.2.0"
+            },
+            "dependencies": {
+                "postcss-value-parser": {
+                    "version": "4.2.0",
+                    "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
+                    "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
+                    "dev": true
+                }
+            }
+        },
         "@discoveryjs/json-ext": {
             "version": "0.5.6",
             "resolved": "https://registry.npmjs.org/@discoveryjs/json-ext/-/json-ext-0.5.6.tgz",
@@ -12761,6 +12833,48 @@
                 "randomfill": "^1.0.3"
             }
         },
+        "css-blank-pseudo": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/css-blank-pseudo/-/css-blank-pseudo-3.0.2.tgz",
+            "integrity": "sha512-hOb1LFjRR+8ocA071xUSmg5VslJ8NGo/I2qpUpdeAYyBVCgupS5O8SEVo4SxEMYyFBNodBkzG3T1iqW9HCXxew==",
+            "dev": true,
+            "requires": {
+                "postcss-selector-parser": "^6.0.8"
+            },
+            "dependencies": {
+                "postcss-selector-parser": {
+                    "version": "6.0.9",
+                    "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.9.tgz",
+                    "integrity": "sha512-UO3SgnZOVTwu4kyLR22UQ1xZh086RyNZppb7lLAKBFK8a32ttG5i87Y/P3+2bRSjZNyJ1B7hfFNo273tKe9YxQ==",
+                    "dev": true,
+                    "requires": {
+                        "cssesc": "^3.0.0",
+                        "util-deprecate": "^1.0.2"
+                    }
+                }
+            }
+        },
+        "css-has-pseudo": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/css-has-pseudo/-/css-has-pseudo-3.0.3.tgz",
+            "integrity": "sha512-0gDYWEKaGacwxCqvQ3Ypg6wGdD1AztbMm5h1JsactG2hP2eiflj808QITmuWBpE7sjSEVrAlZhPTVd/nNMj/hQ==",
+            "dev": true,
+            "requires": {
+                "postcss-selector-parser": "^6.0.8"
+            },
+            "dependencies": {
+                "postcss-selector-parser": {
+                    "version": "6.0.9",
+                    "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.9.tgz",
+                    "integrity": "sha512-UO3SgnZOVTwu4kyLR22UQ1xZh086RyNZppb7lLAKBFK8a32ttG5i87Y/P3+2bRSjZNyJ1B7hfFNo273tKe9YxQ==",
+                    "dev": true,
+                    "requires": {
+                        "cssesc": "^3.0.0",
+                        "util-deprecate": "^1.0.2"
+                    }
+                }
+            }
+        },
         "css-loader": {
             "version": "3.6.0",
             "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-3.6.0.tgz",
@@ -12826,6 +12940,12 @@
                 }
             }
         },
+        "css-prefers-color-scheme": {
+            "version": "6.0.3",
+            "resolved": "https://registry.npmjs.org/css-prefers-color-scheme/-/css-prefers-color-scheme-6.0.3.tgz",
+            "integrity": "sha512-4BqMbZksRkJQx2zAjrokiGMd07RqOa2IxIrrN10lyBe9xhn9DEvjUK79J6jkeiv9D9hQFXKb6g1jwU62jziJZA==",
+            "dev": true
+        },
         "css-select": {
             "version": "4.1.3",
             "resolved": "https://registry.npmjs.org/css-select/-/css-select-4.1.3.tgz",
@@ -12861,6 +12981,12 @@
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/css-what/-/css-what-5.0.1.tgz",
             "integrity": "sha512-FYDTSHb/7KXsWICVsxdmiExPjCfRC4qRFBdVwv7Ax9hMnvMmEjP9RfxTEZ3qPZGmADDn2vAKSo9UcN1jKVYscg==",
+            "dev": true
+        },
+        "cssdb": {
+            "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/cssdb/-/cssdb-6.1.0.tgz",
+            "integrity": "sha512-tZEDdN57Wlb5DRbOpJI9hSoP0t6DjtzSRswFoWo0hmJxfAXTBuDAcp2Oybj6BgQ+sErs9hXnWS1kzYKDKHanmg==",
             "dev": true
         },
         "cssesc": {
@@ -19962,6 +20088,24 @@
                 "source-map-js": "^1.0.1"
             }
         },
+        "postcss-attribute-case-insensitive": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/postcss-attribute-case-insensitive/-/postcss-attribute-case-insensitive-5.0.0.tgz",
+            "integrity": "sha512-b4g9eagFGq9T5SWX4+USfVyjIb3liPnjhHHRMP7FMB2kFVpYyfEscV0wP3eaXhKlcHKUut8lt5BGoeylWA/dBQ==",
+            "dev": true,
+            "requires": {
+                "postcss-selector-parser": "^6.0.2"
+            }
+        },
+        "postcss-clamp": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/postcss-clamp/-/postcss-clamp-3.0.0.tgz",
+            "integrity": "sha512-QENQMIF/Grw0qX0RzSPJjw+mAiGPIwG2AnsQDIoR/WJ5Q19zLB0NrZX8cH7CzzdDWEerTPGCdep7ItFaAdtItg==",
+            "dev": true,
+            "requires": {
+                "postcss-value-parser": "^4.1.0"
+            }
+        },
         "postcss-cli": {
             "version": "8.3.1",
             "resolved": "https://registry.npmjs.org/postcss-cli/-/postcss-cli-8.3.1.tgz",
@@ -20033,6 +20177,144 @@
                 }
             }
         },
+        "postcss-color-functional-notation": {
+            "version": "4.2.1",
+            "resolved": "https://registry.npmjs.org/postcss-color-functional-notation/-/postcss-color-functional-notation-4.2.1.tgz",
+            "integrity": "sha512-62OBIXCjRXpQZcFOYIXwXBlpAVWrYk8ek1rcjvMING4Q2cf0ipyN9qT+BhHA6HmftGSEnFQu2qgKO3gMscl3Rw==",
+            "dev": true,
+            "requires": {
+                "postcss-value-parser": "^4.2.0"
+            },
+            "dependencies": {
+                "postcss-value-parser": {
+                    "version": "4.2.0",
+                    "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
+                    "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
+                    "dev": true
+                }
+            }
+        },
+        "postcss-color-hex-alpha": {
+            "version": "8.0.2",
+            "resolved": "https://registry.npmjs.org/postcss-color-hex-alpha/-/postcss-color-hex-alpha-8.0.2.tgz",
+            "integrity": "sha512-gyx8RgqSmGVK156NAdKcsfkY3KPGHhKqvHTL3hhveFrBBToguKFzhyiuk3cljH6L4fJ0Kv+JENuPXs1Wij27Zw==",
+            "dev": true,
+            "requires": {
+                "postcss-value-parser": "^4.2.0"
+            },
+            "dependencies": {
+                "postcss-value-parser": {
+                    "version": "4.2.0",
+                    "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
+                    "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
+                    "dev": true
+                }
+            }
+        },
+        "postcss-color-rebeccapurple": {
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/postcss-color-rebeccapurple/-/postcss-color-rebeccapurple-7.0.2.tgz",
+            "integrity": "sha512-SFc3MaocHaQ6k3oZaFwH8io6MdypkUtEy/eXzXEB1vEQlO3S3oDc/FSZA8AsS04Z25RirQhlDlHLh3dn7XewWw==",
+            "dev": true,
+            "requires": {
+                "postcss-value-parser": "^4.2.0"
+            },
+            "dependencies": {
+                "postcss-value-parser": {
+                    "version": "4.2.0",
+                    "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
+                    "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
+                    "dev": true
+                }
+            }
+        },
+        "postcss-custom-media": {
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/postcss-custom-media/-/postcss-custom-media-8.0.0.tgz",
+            "integrity": "sha512-FvO2GzMUaTN0t1fBULDeIvxr5IvbDXcIatt6pnJghc736nqNgsGao5NT+5+WVLAQiTt6Cb3YUms0jiPaXhL//g==",
+            "dev": true
+        },
+        "postcss-custom-properties": {
+            "version": "12.1.4",
+            "resolved": "https://registry.npmjs.org/postcss-custom-properties/-/postcss-custom-properties-12.1.4.tgz",
+            "integrity": "sha512-i6AytuTCoDLJkWN/MtAIGriJz3j7UX6bV7Z5t+KgFz+dwZS15/mlTJY1S0kRizlk6ba0V8u8hN50Fz5Nm7tdZw==",
+            "dev": true,
+            "requires": {
+                "postcss-value-parser": "^4.2.0"
+            },
+            "dependencies": {
+                "postcss-value-parser": {
+                    "version": "4.2.0",
+                    "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
+                    "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
+                    "dev": true
+                }
+            }
+        },
+        "postcss-custom-selectors": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/postcss-custom-selectors/-/postcss-custom-selectors-6.0.0.tgz",
+            "integrity": "sha512-/1iyBhz/W8jUepjGyu7V1OPcGbc636snN1yXEQCinb6Bwt7KxsiU7/bLQlp8GwAXzCh7cobBU5odNn/2zQWR8Q==",
+            "dev": true,
+            "requires": {
+                "postcss-selector-parser": "^6.0.4"
+            }
+        },
+        "postcss-dir-pseudo-class": {
+            "version": "6.0.3",
+            "resolved": "https://registry.npmjs.org/postcss-dir-pseudo-class/-/postcss-dir-pseudo-class-6.0.3.tgz",
+            "integrity": "sha512-qiPm+CNAlgXiMf0J5IbBBEXA9l/Q5HGsNGkL3znIwT2ZFRLGY9U2fTUpa4lqCUXQOxaLimpacHeQC80BD2qbDw==",
+            "dev": true,
+            "requires": {
+                "postcss-selector-parser": "^6.0.8"
+            },
+            "dependencies": {
+                "postcss-selector-parser": {
+                    "version": "6.0.9",
+                    "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.9.tgz",
+                    "integrity": "sha512-UO3SgnZOVTwu4kyLR22UQ1xZh086RyNZppb7lLAKBFK8a32ttG5i87Y/P3+2bRSjZNyJ1B7hfFNo273tKe9YxQ==",
+                    "dev": true,
+                    "requires": {
+                        "cssesc": "^3.0.0",
+                        "util-deprecate": "^1.0.2"
+                    }
+                }
+            }
+        },
+        "postcss-double-position-gradients": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/postcss-double-position-gradients/-/postcss-double-position-gradients-3.0.4.tgz",
+            "integrity": "sha512-qz+s5vhKJlsHw8HjSs+HVk2QGFdRyC68KGRQGX3i+GcnUjhWhXQEmCXW6siOJkZ1giu0ddPwSO6I6JdVVVPoog==",
+            "dev": true,
+            "requires": {
+                "postcss-value-parser": "^4.2.0"
+            },
+            "dependencies": {
+                "postcss-value-parser": {
+                    "version": "4.2.0",
+                    "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
+                    "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
+                    "dev": true
+                }
+            }
+        },
+        "postcss-env-function": {
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/postcss-env-function/-/postcss-env-function-4.0.4.tgz",
+            "integrity": "sha512-0ltahRTPtXSIlEZFv7zIvdEib7HN0ZbUQxrxIKn8KbiRyhALo854I/CggU5lyZe6ZBvSTJ6Al2vkZecI2OhneQ==",
+            "dev": true,
+            "requires": {
+                "postcss-value-parser": "^4.2.0"
+            },
+            "dependencies": {
+                "postcss-value-parser": {
+                    "version": "4.2.0",
+                    "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
+                    "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
+                    "dev": true
+                }
+            }
+        },
         "postcss-flexbugs-fixes": {
             "version": "4.2.1",
             "resolved": "https://registry.npmjs.org/postcss-flexbugs-fixes/-/postcss-flexbugs-fixes-4.2.1.tgz",
@@ -20066,6 +20348,83 @@
                 }
             }
         },
+        "postcss-focus-visible": {
+            "version": "6.0.3",
+            "resolved": "https://registry.npmjs.org/postcss-focus-visible/-/postcss-focus-visible-6.0.3.tgz",
+            "integrity": "sha512-ozOsg+L1U8S+rxSHnJJiET6dNLyADcPHhEarhhtCI9DBLGOPG/2i4ddVoFch9LzrBgb8uDaaRI4nuid2OM82ZA==",
+            "dev": true,
+            "requires": {
+                "postcss-selector-parser": "^6.0.8"
+            },
+            "dependencies": {
+                "postcss-selector-parser": {
+                    "version": "6.0.9",
+                    "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.9.tgz",
+                    "integrity": "sha512-UO3SgnZOVTwu4kyLR22UQ1xZh086RyNZppb7lLAKBFK8a32ttG5i87Y/P3+2bRSjZNyJ1B7hfFNo273tKe9YxQ==",
+                    "dev": true,
+                    "requires": {
+                        "cssesc": "^3.0.0",
+                        "util-deprecate": "^1.0.2"
+                    }
+                }
+            }
+        },
+        "postcss-focus-within": {
+            "version": "5.0.3",
+            "resolved": "https://registry.npmjs.org/postcss-focus-within/-/postcss-focus-within-5.0.3.tgz",
+            "integrity": "sha512-fk9y2uFS6/Kpp7/A9Hz9Z4rlFQ8+tzgBcQCXAFSrXFGAbKx+4ZZOmmfHuYjCOMegPWoz0pnC6fNzi8j7Xyqp5Q==",
+            "dev": true,
+            "requires": {
+                "postcss-selector-parser": "^6.0.8"
+            },
+            "dependencies": {
+                "postcss-selector-parser": {
+                    "version": "6.0.9",
+                    "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.9.tgz",
+                    "integrity": "sha512-UO3SgnZOVTwu4kyLR22UQ1xZh086RyNZppb7lLAKBFK8a32ttG5i87Y/P3+2bRSjZNyJ1B7hfFNo273tKe9YxQ==",
+                    "dev": true,
+                    "requires": {
+                        "cssesc": "^3.0.0",
+                        "util-deprecate": "^1.0.2"
+                    }
+                }
+            }
+        },
+        "postcss-font-variant": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/postcss-font-variant/-/postcss-font-variant-5.0.0.tgz",
+            "integrity": "sha512-1fmkBaCALD72CK2a9i468mA/+tr9/1cBxRRMXOUaZqO43oWPR5imcyPjXwuv7PXbCid4ndlP5zWhidQVVa3hmA==",
+            "dev": true
+        },
+        "postcss-gap-properties": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/postcss-gap-properties/-/postcss-gap-properties-3.0.2.tgz",
+            "integrity": "sha512-EaMy/pbxtQnKDsnbEjdqlkCkROTQZzolcLKgIE+3b7EuJfJydH55cZeHfm+MtIezXRqhR80VKgaztO/vHq94Fw==",
+            "dev": true
+        },
+        "postcss-image-set-function": {
+            "version": "4.0.5",
+            "resolved": "https://registry.npmjs.org/postcss-image-set-function/-/postcss-image-set-function-4.0.5.tgz",
+            "integrity": "sha512-D4jXzlypkJ6BiSoUGazrRlR+GF3SED+BeiRDzOmuinDKdAn/Wuu8KtEGa5Z4pg4kxyeSMBywMgNt2+Yi/TZPPw==",
+            "dev": true,
+            "requires": {
+                "postcss-value-parser": "^4.2.0"
+            },
+            "dependencies": {
+                "postcss-value-parser": {
+                    "version": "4.2.0",
+                    "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
+                    "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
+                    "dev": true
+                }
+            }
+        },
+        "postcss-initial": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/postcss-initial/-/postcss-initial-4.0.1.tgz",
+            "integrity": "sha512-0ueD7rPqX8Pn1xJIjay0AZeIuDoF+V+VvMt/uOnn+4ezUKhZM/NokDeP6DwMNyIoYByuN/94IQnt5FEkaN59xQ==",
+            "dev": true
+        },
         "postcss-js": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/postcss-js/-/postcss-js-4.0.0.tgz",
@@ -20073,6 +20432,23 @@
             "dev": true,
             "requires": {
                 "camelcase-css": "^2.0.1"
+            }
+        },
+        "postcss-lab-function": {
+            "version": "4.0.3",
+            "resolved": "https://registry.npmjs.org/postcss-lab-function/-/postcss-lab-function-4.0.3.tgz",
+            "integrity": "sha512-MH4tymWmefdZQ7uVG/4icfLjAQmH6o2NRYyVh2mKoB4RXJp9PjsyhZwhH4ouaCQHvg+qJVj3RzeAR1EQpIlXZA==",
+            "dev": true,
+            "requires": {
+                "postcss-value-parser": "^4.2.0"
+            },
+            "dependencies": {
+                "postcss-value-parser": {
+                    "version": "4.2.0",
+                    "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
+                    "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
+                    "dev": true
+                }
             }
         },
         "postcss-load-config": {
@@ -20132,6 +20508,18 @@
                     }
                 }
             }
+        },
+        "postcss-logical": {
+            "version": "5.0.3",
+            "resolved": "https://registry.npmjs.org/postcss-logical/-/postcss-logical-5.0.3.tgz",
+            "integrity": "sha512-P5NcHWYrif0vK8rgOy/T87vg0WRIj3HSknrvp1wzDbiBeoDPVmiVRmkown2eSQdpPveat/MC1ess5uhzZFVnqQ==",
+            "dev": true
+        },
+        "postcss-media-minmax": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/postcss-media-minmax/-/postcss-media-minmax-5.0.0.tgz",
+            "integrity": "sha512-yDUvFf9QdFZTuCUg0g0uNSHVlJ5X1lSzDZjPSFaiCWvjgsvu8vEVxtahPrLMinIDEEGnx6cBe6iqdx5YWz08wQ==",
+            "dev": true
         },
         "postcss-modules-extract-imports": {
             "version": "2.0.0",
@@ -20291,6 +20679,168 @@
                 }
             }
         },
+        "postcss-nesting": {
+            "version": "10.1.2",
+            "resolved": "https://registry.npmjs.org/postcss-nesting/-/postcss-nesting-10.1.2.tgz",
+            "integrity": "sha512-dJGmgmsvpzKoVMtDMQQG/T6FSqs6kDtUDirIfl4KnjMCiY9/ETX8jdKyCd20swSRAbUYkaBKV20pxkzxoOXLqQ==",
+            "dev": true,
+            "requires": {
+                "postcss-selector-parser": "^6.0.8"
+            },
+            "dependencies": {
+                "postcss-selector-parser": {
+                    "version": "6.0.9",
+                    "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.9.tgz",
+                    "integrity": "sha512-UO3SgnZOVTwu4kyLR22UQ1xZh086RyNZppb7lLAKBFK8a32ttG5i87Y/P3+2bRSjZNyJ1B7hfFNo273tKe9YxQ==",
+                    "dev": true,
+                    "requires": {
+                        "cssesc": "^3.0.0",
+                        "util-deprecate": "^1.0.2"
+                    }
+                }
+            }
+        },
+        "postcss-opacity-percentage": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/postcss-opacity-percentage/-/postcss-opacity-percentage-1.1.2.tgz",
+            "integrity": "sha512-lyUfF7miG+yewZ8EAk9XUBIlrHyUE6fijnesuz+Mj5zrIHIEw6KcIZSOk/elVMqzLvREmXB83Zi/5QpNRYd47w==",
+            "dev": true
+        },
+        "postcss-overflow-shorthand": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/postcss-overflow-shorthand/-/postcss-overflow-shorthand-3.0.2.tgz",
+            "integrity": "sha512-odBMVt6PTX7jOE9UNvmnLrFzA9pXS44Jd5shFGGtSHY80QCuJF+14McSy0iavZggRZ9Oj//C9vOKQmexvyEJMg==",
+            "dev": true
+        },
+        "postcss-page-break": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/postcss-page-break/-/postcss-page-break-3.0.4.tgz",
+            "integrity": "sha512-1JGu8oCjVXLa9q9rFTo4MbeeA5FMe00/9C7lN4va606Rdb+HkxXtXsmEDrIraQ11fGz/WvKWa8gMuCKkrXpTsQ==",
+            "dev": true
+        },
+        "postcss-place": {
+            "version": "7.0.3",
+            "resolved": "https://registry.npmjs.org/postcss-place/-/postcss-place-7.0.3.tgz",
+            "integrity": "sha512-tDQ3m+GYoOar+KoQgj+pwPAvGHAp/Sby6vrFiyrELrMKQJ4AejL0NcS0mm296OKKYA2SRg9ism/hlT/OLhBrdQ==",
+            "dev": true,
+            "requires": {
+                "postcss-value-parser": "^4.2.0"
+            },
+            "dependencies": {
+                "postcss-value-parser": {
+                    "version": "4.2.0",
+                    "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
+                    "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
+                    "dev": true
+                }
+            }
+        },
+        "postcss-preset-env": {
+            "version": "7.3.1",
+            "resolved": "https://registry.npmjs.org/postcss-preset-env/-/postcss-preset-env-7.3.1.tgz",
+            "integrity": "sha512-x7fNsJxfkY60P4FUNwhJUOfXBFfnObd2EcUYY97sXZ0XRLgmAE65es9EFIYHq1rAk7X3LMfbG+L9wYgkrNsq5Q==",
+            "dev": true,
+            "requires": {
+                "@csstools/postcss-font-format-keywords": "^1.0.0",
+                "@csstools/postcss-hwb-function": "^1.0.0",
+                "@csstools/postcss-is-pseudo-class": "^2.0.0",
+                "@csstools/postcss-normalize-display-values": "^1.0.0",
+                "autoprefixer": "^10.4.2",
+                "browserslist": "^4.19.1",
+                "css-blank-pseudo": "^3.0.2",
+                "css-has-pseudo": "^3.0.3",
+                "css-prefers-color-scheme": "^6.0.3",
+                "cssdb": "^6.1.0",
+                "postcss-attribute-case-insensitive": "^5.0.0",
+                "postcss-clamp": "^3.0.0",
+                "postcss-color-functional-notation": "^4.2.1",
+                "postcss-color-hex-alpha": "^8.0.2",
+                "postcss-color-rebeccapurple": "^7.0.2",
+                "postcss-custom-media": "^8.0.0",
+                "postcss-custom-properties": "^12.1.4",
+                "postcss-custom-selectors": "^6.0.0",
+                "postcss-dir-pseudo-class": "^6.0.3",
+                "postcss-double-position-gradients": "^3.0.4",
+                "postcss-env-function": "^4.0.4",
+                "postcss-focus-visible": "^6.0.3",
+                "postcss-focus-within": "^5.0.3",
+                "postcss-font-variant": "^5.0.0",
+                "postcss-gap-properties": "^3.0.2",
+                "postcss-image-set-function": "^4.0.5",
+                "postcss-initial": "^4.0.1",
+                "postcss-lab-function": "^4.0.3",
+                "postcss-logical": "^5.0.3",
+                "postcss-media-minmax": "^5.0.0",
+                "postcss-nesting": "^10.1.2",
+                "postcss-opacity-percentage": "^1.1.2",
+                "postcss-overflow-shorthand": "^3.0.2",
+                "postcss-page-break": "^3.0.4",
+                "postcss-place": "^7.0.3",
+                "postcss-pseudo-class-any-link": "^7.1.0",
+                "postcss-replace-overflow-wrap": "^4.0.0",
+                "postcss-selector-not": "^5.0.0"
+            },
+            "dependencies": {
+                "browserslist": {
+                    "version": "4.19.1",
+                    "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.19.1.tgz",
+                    "integrity": "sha512-u2tbbG5PdKRTUoctO3NBD8FQ5HdPh1ZXPHzp1rwaa5jTc+RV9/+RlWiAIKmjRPQF+xbGM9Kklj5bZQFa2s/38A==",
+                    "dev": true,
+                    "requires": {
+                        "caniuse-lite": "^1.0.30001286",
+                        "electron-to-chromium": "^1.4.17",
+                        "escalade": "^3.1.1",
+                        "node-releases": "^2.0.1",
+                        "picocolors": "^1.0.0"
+                    }
+                },
+                "caniuse-lite": {
+                    "version": "1.0.30001306",
+                    "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001306.tgz",
+                    "integrity": "sha512-Wd1OuggRzg1rbnM5hv1wXs2VkxJH/AA+LuudlIqvZiCvivF+wJJe2mgBZC8gPMgI7D76PP5CTx8Luvaqc1V6OQ==",
+                    "dev": true
+                },
+                "electron-to-chromium": {
+                    "version": "1.4.63",
+                    "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.63.tgz",
+                    "integrity": "sha512-e0PX/LRJPFRU4kzJKLvTobxyFdnANCvcoDCe8XcyTqP58nTWIwdsHvXLIl1RkB39X5yaosLaroMASWB0oIsgCA==",
+                    "dev": true
+                },
+                "node-releases": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.1.tgz",
+                    "integrity": "sha512-CqyzN6z7Q6aMeF/ktcMVTzhAHCEpf8SOarwpzpf8pNBY2k5/oM34UHldUwp8VKI7uxct2HxSRdJjBaZeESzcxA==",
+                    "dev": true
+                }
+            }
+        },
+        "postcss-pseudo-class-any-link": {
+            "version": "7.1.0",
+            "resolved": "https://registry.npmjs.org/postcss-pseudo-class-any-link/-/postcss-pseudo-class-any-link-7.1.0.tgz",
+            "integrity": "sha512-l7sAkLmm3bYq8wt8/0r/dn6o9mVCPq7MOiNrb/Xi2zBlw/+w1V2jKFo/3IijKHfJ92SwDqkVLPwQfGO3xxUdAw==",
+            "dev": true,
+            "requires": {
+                "postcss-selector-parser": "^6.0.9"
+            },
+            "dependencies": {
+                "postcss-selector-parser": {
+                    "version": "6.0.9",
+                    "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.9.tgz",
+                    "integrity": "sha512-UO3SgnZOVTwu4kyLR22UQ1xZh086RyNZppb7lLAKBFK8a32ttG5i87Y/P3+2bRSjZNyJ1B7hfFNo273tKe9YxQ==",
+                    "dev": true,
+                    "requires": {
+                        "cssesc": "^3.0.0",
+                        "util-deprecate": "^1.0.2"
+                    }
+                }
+            }
+        },
+        "postcss-replace-overflow-wrap": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/postcss-replace-overflow-wrap/-/postcss-replace-overflow-wrap-4.0.0.tgz",
+            "integrity": "sha512-KmF7SBPphT4gPPcKZc7aDkweHiKEEO8cla/GjcBK+ckKxiZslIu3C4GCRW3DNfL0o7yW7kMQu9xlZ1kXRXLXtw==",
+            "dev": true
+        },
         "postcss-reporter": {
             "version": "7.0.5",
             "resolved": "https://registry.npmjs.org/postcss-reporter/-/postcss-reporter-7.0.5.tgz",
@@ -20299,6 +20849,15 @@
             "requires": {
                 "picocolors": "^1.0.0",
                 "thenby": "^1.3.4"
+            }
+        },
+        "postcss-selector-not": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/postcss-selector-not/-/postcss-selector-not-5.0.0.tgz",
+            "integrity": "sha512-/2K3A4TCP9orP4TNS7u3tGdRFVKqz/E6pX3aGnriPG0jU78of8wsUcqE4QAhWEU0d+WnMSF93Ah3F//vUtK+iQ==",
+            "dev": true,
+            "requires": {
+                "balanced-match": "^1.0.0"
             }
         },
         "postcss-selector-parser": {

--- a/package.json
+++ b/package.json
@@ -21,6 +21,14 @@
         "release": "npx auto shipit --base-branch=main",
         "optimize-svgs": "gulp"
     },
+    "browserslist": [
+        "last 2 versions",
+        "IE 11",
+        "Firefox ESR",
+        "iOS >= 8",
+        "Safari >= 8",
+        "> 2.5% in DE"
+    ],
     "keywords": [],
     "devDependencies": {
         "@babel/cli": "^7.13.16",

--- a/package.json
+++ b/package.json
@@ -25,8 +25,8 @@
         "last 2 versions",
         "IE 11",
         "Firefox ESR",
-        "iOS >= 8",
-        "Safari >= 8",
+        "iOS >= 10",
+        "Safari >= 10",
         "> 2.5% in DE"
     ],
     "keywords": [],

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
         "path": "^0.12.7",
         "postcss": "^8.4.5",
         "postcss-cli": "^8.3.1",
+        "postcss-preset-env": "^7.3.1",
         "prettier": "^2.2.1",
         "rimraf": "^3.0.2",
         "storybook-conditional-toolbar-selector": "^1.0.3",

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,3 +1,3 @@
 module.exports = {
-  plugins: [require("tailwindcss"), require("autoprefixer")],
-};
+    plugins: [require('tailwindcss'), require('postcss-preset-env')],
+}


### PR DESCRIPTION
Integriert das postcss Plugin postcss-preset-env und das browserslist Property in der package.json in den Build Workflow. Hierdurch wird, sofern technisch möglich, neue CSS Syntax in alte automatisiert umgewandelt. Zahlreiche eigentlich in alten Browsern nicht mehr nutzbare Features von Tailwindcss können so auch dort noch verwendet werden.