### PR TITLE
FEATURE: employs a loadDynamic template as a

### DIFF
--- a/build/helpers/case.js
+++ b/build/helpers/case.js
@@ -1,5 +1,6 @@
 module.exports = function (value, options) {
-  this.switch_value = value;
-  this.switch_break = false;
-  return options.fn(this);
-};
+    if (value == this.switch_value) {
+        this.switch_break = true
+        return options.fn(this)
+    }
+}

--- a/build/helpers/switch.js
+++ b/build/helpers/switch.js
@@ -1,6 +1,5 @@
 module.exports = function (value, options) {
-  if (value == this.switch_value) {
-    this.switch_break = true;
-    return options.fn(this);
-  }
-};
+    this.switch_value = value
+    this.switch_break = false
+    return options.fn(this)
+}

--- a/src/stories/views/components/Header/ServiceNavigation/ServiceList.hbs
+++ b/src/stories/views/components/Header/ServiceNavigation/ServiceList.hbs
@@ -8,12 +8,7 @@
     {{#with this.serviceNavigationSSILinks}}
         <ul class="flex justify-around w-full h-full -itemCount-{{ count }} lg:w-auto lg:justify-end lg:pt-1">
             {{#each this}}        
-                {{!-- {{> components/base/loadSSI _template='components/Header/ServiceNavigation/ServiceNavigationItem' }} --}}                    
-                {{#if (isStorybook)}}  
-                    {{> components/Header/ServiceNavigation/ServiceNavigationItem }}   
-                {{else}}
-                    {{{this}}}
-                {{/if}}          
+                {{> components/base/loadSSI templatePath='components/Header/ServiceNavigation/ServiceNavigationItem' }}               
             {{/each}} 
         </ul>
     {{/with}}

--- a/src/stories/views/components/base/loadDynamic.hbs
+++ b/src/stories/views/components/base/loadDynamic.hbs
@@ -1,0 +1,5 @@
+{{#switch templatePath}}
+    {{#case "components/Header/ServiceNavigation/ServiceNavigationItem"}}
+        {{> components/Header/ServiceNavigation/ServiceNavigationItem}}
+    {{/case}}
+{{/switch}}

--- a/src/stories/views/components/base/loadSSI.hbs
+++ b/src/stories/views/components/base/loadSSI.hbs
@@ -1,5 +1,5 @@
 {{#if (isStorybook)}}  
-    {{> (lookup . '_template') }}   
+    {{> components/base/loadDynamic templatePath=templatePath}} 
 {{else}}
     {{{this}}}
 {{/if}}        


### PR DESCRIPTION
workaround for the unusable lookup helper

When including the loadDynamic template the
path to the template that needs to be loaded has
to be defined with the help of the templatePath parameter. Unfortunately the solution isn't as
dynamic as the name might suggest.
Any template
that should be loaded via that template needs to have a hardcoded include inside the template.