### PR TITLE
Words in byline get wrapped when the

### DIFF
--- a/src/stories/views/components/teaser/components/teaser_byline.hbs
+++ b/src/stories/views/components/teaser/components/teaser_byline.hbs
@@ -1,5 +1,5 @@
 {{#if this.hasByline}}
-    <p class="mt-2 text-xs text-grey-scorpion font-headingSerif empty:hidden">
+    <p class="mt-2 text-xs text-grey-scorpion font-headingSerif empty:hidden overflow-anywhere hyphens-auto">
         {{!--Teaser-Info--}}
         {{~#with this.teaserInfo~}}
             {{~#if this.showTeaserInfo~}}


### PR DESCRIPTION
word is too long for the line.