### PR TITLE
BUGFIX: Prefixess all partial properties

### DIFF
--- a/src/stories/views/components/site_header/navigation_flyout/navigation_flyout.hbs
+++ b/src/stories/views/components/site_header/navigation_flyout/navigation_flyout.hbs
@@ -43,11 +43,11 @@
         <div class="{{#if this.showAsFlyout}}lg:flex lg:flex-row -columnCount--{{this.columnCount}} lg:divide-x lg:divide-gray-200 {{else}} {{#if ../this.selected}} w-full lg:px-10 lg:container {{/if}}{{/if}}">
             {{#if this.showAsFlyout}}
                 {{#each this.columns}}
-                    {{> components/site_header/navigation_flyout/navigation_flyout_column count=../this.columnCount navtype=../../_navigationType _parent=../../_parent _flyout=true~}}
+                    {{> components/site_header/navigation_flyout/navigation_flyout_column _count=../this.columnCount _navtype=../../_navigationType _parent=../../_parent _flyout=true~}}
                 {{/each}}
             {{else}}
                 {{#with this.items}}
-                    {{> components/site_header/navigation_flyout/navigation_flyout_column selected=../../this.selected navtype=../../_navigationType _parent=../../_parent _flyout=false ~}}
+                    {{> components/site_header/navigation_flyout/navigation_flyout_column _selected=../../this.selected _navtype=../../_navigationType _parent=../../_parent _flyout=false ~}}
                 {{/with}}
             {{/if}}
         </div>

--- a/src/stories/views/components/site_header/navigation_flyout/navigation_flyout_column.hbs
+++ b/src/stories/views/components/site_header/navigation_flyout/navigation_flyout_column.hbs
@@ -1,7 +1,7 @@
-<ul class="{{inline-switch count '["1","2"]' '["md:w-1/1", "md:w-1/1 lg:w-1/2"]'}} {{inline-switch navtype '["ServiceNavigation","RubrikNavigation"]' '["border-b border-gray-200 md:border-0","border-0"]'}} lg:even:pl-4 lg:odd:pr-4 {{#if selected}} lg:container lg:flex lg:h-9 {{/if}} ">
+<ul class="{{inline-switch _count '["1","2"]' '["md:w-1/1", "md:w-1/1 lg:w-1/2"]'}} {{inline-switch _navtype '["ServiceNavigation","RubrikNavigation"]' '["border-b border-gray-200 md:border-0","border-0"]'}} lg:even:pl-4 lg:odd:pr-4 {{#if _selected}} lg:container lg:flex lg:h-9 {{/if}} ">
     {{~#each this ~}} 
         {{~#if this.title~}}
-            {{> components/site_header/navigation_flyout/navigation_flyout_item _parentselected=../selected _fromNav=../navtype _flyout=../_flyout _parent=../_parent ~}}
+            {{> components/site_header/navigation_flyout/navigation_flyout_item _parentselected=../_selected _fromNav=../_navtype _flyout=../_flyout _parent=../_parent ~}}
         {{~/if~}}       
     {{~/each~}}
     


### PR DESCRIPTION
Prefixess all partial properties with an underscore to make sure
that the names don't interfere with
variable names from the json
fixtures.