### PR TITLE
Bugfix/2829

### DIFF
--- a/src/stories/views/base/tracking/pianoHelper.subfeature.js
+++ b/src/stories/views/base/tracking/pianoHelper.subfeature.js
@@ -6,7 +6,7 @@ const isTrackingAllowed = () => {
 }
 
 const uxAction = (label, secondLevelId) => {
-    secondLevelId = secondLevelId || pageDisplayConfig.site_level2
+    secondLevelId = secondLevelId || typeof pageDisplayConfig != "undefined" && pageDisplayConfig != undefined ? pageDisplayConfig.site_level2_id:99
     if (typeof pa != "undefined" && pa != undefined && isTrackingAllowed()) {
         pa.sendEvent('click.action', {
             click: label,
@@ -16,7 +16,7 @@ const uxAction = (label, secondLevelId) => {
 }
 
 const uxNavigation = (label, secondLevelId) => {
-    secondLevelId = secondLevelId || pageDisplayConfig.site_level2
+    secondLevelId = secondLevelId || typeof pageDisplayConfig != "undefined" && pageDisplayConfig != undefined ? pageDisplayConfig.site_level2_id:99
     if (typeof pa != "undefined" && pa != undefined  && isTrackingAllowed()) {
         pa.sendEvent('click.navigation', {
             click: label,
@@ -32,7 +32,7 @@ const pi = () => {
 }
 
 const download = (label, secondLevelId) => {
-    secondLevelId = secondLevelId || pageDisplayConfig.site_level2
+    secondLevelId = secondLevelId || typeof pageDisplayConfig != "undefined" && pageDisplayConfig != undefined ? pageDisplayConfig.site_level2_id:99
     if (typeof pa != "undefined" && pa != undefined  && isTrackingAllowed()) {
         pa.sendEvent('click.download', {
             click: label,

--- a/src/stories/views/components/base/link.hbs
+++ b/src/stories/views/components/base/link.hbs
@@ -1,4 +1,4 @@
-<a {{#with _link.webviewUrl}}data-webviewurl="{{this}}"{{/with}} {{#if _link.isStaticUrl}}href="{{resourceUrl _link.url}}{{else}}href="{{_link.url}}{{/if}}{{#if this.hasComments}}#commentList{{/if}}"
+<a {{#with _link.webviewUrl}}data-webviewurl="{{this}}"{{/with}} {{#if _link.isStaticUrl}}href="{{#if _link.site}}{{resourceUrl _link.url _site=_link.site}}{{else}}{{resourceUrl _link.url}}{{/if}}{{else}}href="{{_link.url}}{{/if}}{{#if this.hasComments}}#commentList{{/if}}"
     class="sb-link ds-link js-load {{#if _isSelected}} {{defaultIfEmpty _selectedCssClass "-current"}}{{/if}}{{#if _css}} {{_css}}{{/if}} {{#> css}}{{/css}}"
     {{#if _link.isTargetBlank}} target="_blank"  rel="noopener{{#if _link.hasNoReferrerFlag}} noreferrer{{/if}}"{{/if}}
     {{#if _isAriaHidden}} aria-hidden="true" tabindex="-1"{{/if}}


### PR DESCRIPTION
- makes sure that in pianoHelper.subfeature.js the object pageDisplayConfig is present before accessing it
- the link template is now able to generate static urls to different brands