### PR TITLE
Implemented 'layout: fullscreen' parameter in Storybook configuration…

### DIFF
--- a/src/stories/views/components/page/story/story_main.stories.js
+++ b/src/stories/views/components/page/story/story_main.stories.js
@@ -15,4 +15,7 @@ export const Default = {
     render: Template.bind({}),
     name: 'default',
     args: story_json,
+    parameters: {
+        layout: 'fullscreen',
+    }    
 }


### PR DESCRIPTION
Implemented 'layout: fullscreen' parameter in Storybook configuratio to render story without body margin.

By introducing the 'layout: fullscreen' parameter in Storybook configuration, the rendering of stories is now free from the 'sb-main-padded' class, eliminating the surrounding padding of 1rem on the body tag. This enhancement ensures a cleaner and more consistent visual presentation.