### PR TITLE
:bug: Make sure that the regex in the loca helper only matches when it recognizes numbers in between opening and closing curly braces.

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -17,9 +17,9 @@ import '../src/assets/tailwind.css'
 import { CheckCSS } from 'checkcss';
 
 configureActions({
-    clearOnStoryChange: true, 
-  });
-  
+    clearOnStoryChange: true,
+});
+
 // Create CheckCSS instance
 const checkcss = new CheckCSS();
 
@@ -34,8 +34,8 @@ checkcss.onClassnameDetected = function (classname, element) {
 checkcss.onUndefinedClassname = function (classname) {
     console.log(
         `checkcss: No CSS rule for .${classname}`,
-      );
-  };
+    );
+};
 
 checkcss.scan().watch();
 
@@ -43,7 +43,7 @@ const panelInclude = setConsoleOptions({}).panelInclude;
 
 setConsoleOptions({
     panelInclude: [...panelInclude, /checkcss/],
-}); 
+});
 
 
 function loadDelayedImages() {
@@ -74,16 +74,10 @@ let eventSrcUrl = null
 
 document.addEventListener('DOMContentLoaded', function (event) {
     console.log('DOM fully loaded and parsed')
-    if (eventSrcUrl != event.srcElement.URL) {
-        eventSrcUrl = event.srcElement.URL
+    console.log('Start feature initialization')
 
-        console.log('Start feature initialization')
-
-        Initializer.run(document, loadFeature)
-        setTimeout(loadDelayedImages, 200)
-    } else {
-        console.log('second DOMContentLoaded Event was blocked!')
-    }
+    Initializer.run(document, loadFeature)
+    setTimeout(loadDelayedImages, 200)
 })
 
 /*if (process.env.NODE_ENV !== 'production') {

--- a/build/handlebars/helpers/handlebar-helpers.js
+++ b/build/handlebars/helpers/handlebar-helpers.js
@@ -430,7 +430,7 @@ var helpers = {
                     const args = Array.prototype.slice.call(arguments);
                     // Extract params from arguments object. No params are present when length of arguments array is <= 2
                     let params = args.length > 2 ? args.slice(1, args.length - 1) : []
-                    const regex = /(?<property>{<%(?<propertyKey>.*?)%>})|(?<userConsent>{nuc\s(?<userConsentUrl>.*?)\snuc})|(?<param>{(?<paramKey>.*?)})/g
+                    const regex = /(?<property>{<%(?<propertyKey>.*?)%>})|(?<userConsent>{nuc\s(?<userConsentUrl>.*?)\snuc})|(?<param>{(?<paramKey>\d*?)})/g
                     const matches = loca.matchAll(regex)
                     const placeHolders = []
                     for (const match of matches) {


### PR DESCRIPTION
In a locatag like "avStart = false; $dispatch('player_closed',{playerId: {0}})" it now only matches {0} and not {playerId: {0}}.