### PR TITLE
SEO BUG - livestream player images allways prefetched

### DIFF
--- a/src/stories/views/components/content/copytext/components/media/media_figure.hbs
+++ b/src/stories/views/components/content/copytext/components/media/media_figure.hbs
@@ -28,11 +28,11 @@
     {{/if}}
     {{#if this.isVideoOnDemand}}
         {{~> components/mediaplayer/media_player this.toModel.videoElement _uiTestHook="ui-test-video-ondemand-player" _isUsedInTeaser=true _addClassImg=_addClassImg ~}}
-        {{~> components/teaser/components/teaser_media_player this _css="flex items-center justify-center" _isLead=_isLead _isUsedInCopytext=true _mediaButtonIcon="play_button" _mediaButtonLabel="Video" _aspectRatio="ar-16-9" _noDelay=(if _isLead true false)}}
+        {{~> components/teaser/components/teaser_media_player this _css="flex items-center justify-center" _isLead=_isLead _isUsedInCopytext=true _mediaButtonIcon="play_button" _mediaButtonLabel="Video" _aspectRatio="ar-16-9" _noDelay=_isLead }}
     {{/if}}
     {{#if this.isLivestream}}
         {{~> components/mediaplayer/media_player this.toModel.videoLivestreamElement _uiTestHook="ui-test-video-ondemand-player" _isUsedInTeaser=true _addClassImg=_addClassImg ~}}
-        {{~> components/teaser/components/teaser_media_player this _css="flex items-center justify-center" _isLivestream=true _isLead=_isLead _isUsedInCopytext=true _mediaButtonIcon="play_button" _mediaButtonLabel="Live" _aspectRatio="ar-16-9" _noDelay=(if _isLead true false)}}
+        {{~> components/teaser/components/teaser_media_player this _css="flex items-center justify-center" _isLivestream=true _isLead=_isLead _isUsedInCopytext=true _mediaButtonIcon="play_button" _mediaButtonLabel="Live" _aspectRatio="ar-16-9" _noDelay=_isLead }}
     {{/if}}
     {{#unless _voting-option}}
         {{#if this.teaseritem}}


### PR DESCRIPTION
removed inline if because instead of passing a Boolean true or false it passes a String. This caused the problem that the images were always prefetched in video players