### PR TITLE
:bug: Set an initial height in copytext-ds__icon class so that

### DIFF
--- a/src/assets/css/custom-components.css
+++ b/src/assets/css/custom-components.css
@@ -316,13 +316,7 @@ article.indexTextDS .indexTextHighlighted .link {
     }
 
     &__icon {
-        @apply inline -mt-0.5 fill-current ml-1;
-    }
-
-    &__box {
-        .copytext-ds__icon {
-            @apply w-5 h-5;
-        }
+        @apply inline w-5 h-5 -mt-0.5 fill-current ml-1;
     }
 
     &__paragraph {


### PR DESCRIPTION
the icon in the figcaption of an image also gets a width and height.