### PR TITLE
:sparkles: Allow to define json settings in a child node  of the trac…

### DIFF
--- a/src/stories/views/base/tracking/clickTracking.feature.js
+++ b/src/stories/views/base/tracking/clickTracking.feature.js
@@ -1,8 +1,11 @@
 import { download, pi, uxAction, uxNavigation } from 'base/tracking/pianoHelper.subfeature';
+import { hr$ } from 'hrQuery'
 
 const ClickTracking = (context) => {
     const { options, element: elementToTrack } = context;
-    const settings = options.settings || [];
+    const settingsFromChildNode = JSON.parse(hr$('[data-click-tracking-settings]', elementToTrack)[0]?.dataset.clickTrackingSettings || '{"settings":[]}')
+        .settings || '[]';
+    const settings = options.settings || settingsFromChildNode;
 
     const clickHandler = (event) => {
         settings.forEach(({ type, clickLabel, secondLevelId }) => {


### PR DESCRIPTION
…kable element. If settings are defined directly in the data-hr-click-tracking attribute of the trackable element they are used and otherwise a data-attribute data-click-tracking-settings is used to extract settings information